### PR TITLE
Updated dependencies for TNS 3

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -6,17 +6,17 @@
   "nativescript": {
     "id": "org.nativescript.demo",
     "tns-ios": {
-      "version": "2.5.0"
+      "version": "3.0.1"
     }
   },
   "dependencies": {
-    "nativescript-lan-scan": "../",
-    "nativescript-theme-core": "~1.0.2",
-    "tns-core-modules": "2.5.0"
+    "nativescript-lan-scan": "..",
+    "nativescript-theme-core": "~1.0.4",
+    "tns-core-modules": "^3.0.1"
   },
   "devDependencies": {
     "nativescript-dev-android-snapshot": "^0.*.*",
-    "nativescript-dev-typescript": "~0.3.5",
-    "typescript": "~2.1.0"
+    "nativescript-dev-typescript": "~0.4.5",
+    "typescript": "~2.2.1"
   }
 }

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,11 +1,22 @@
 {
     "compilerOptions": {
+        "lib": [
+            "es6",
+            "dom"
+        ],
         "module": "commonjs",
         "target": "es5",
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
-        "noEmitOnError": true
+        "noEmitOnError": true,
+        "baseUrl": ".",
+        "paths": {
+            "*": [
+                "./node_modules/tns-core-modules/*",
+                "./node_modules/*"
+            ]
+        }
     },
     "exclude": [
         "node_modules",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "nativescript-lan-scan",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "NativeScript wrapper for iOS MMLanScan CocoaPod [BETA]",
   "main": "lan-scan",
-  "typings": "index.d.ts",
+  "typings": "lan-scan.d.ts",
   "nativescript": {
     "platforms": {
-      "ios": "2.3.0"
+      "ios": "3.0.1"
     },
     "tns-ios": {
-      "version": "2.5.0"
+      "version": "3.0.1"
     }
   },
   "scripts": {
@@ -44,13 +44,10 @@
   "homepage": "https://github.com/BurkeHolland/nativescript-lan-scan",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "tns-core-modules": "^2.3.0",
-    "tns-platform-declarations": "^2.3.0",
-    "typescript": "^2.0.7",
+    "tns-core-modules": "^3.0.1",
+    "tns-platform-declarations": "^3.0.1",
+    "typescript": "^2.2.1",
     "prompt": "^1.0.0",
-    "rimraf": "^2.5.0"
-  },
-  "dependencies": {
-    "tns-core-modules": "^2.5.0"
+    "rimraf": "^2.6.1"
   }
 }

--- a/references.d.ts
+++ b/references.d.ts
@@ -1,2 +1,1 @@
-/// <reference path="./node_modules/tns-core-modules/tns-core-modules.d.ts" />
 /// <reference path="./node_modules/typescript/lib/lib.d.ts" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "lib": [
+            "es6",
             "dom"
         ],
         "sourceMap": true,
@@ -26,7 +27,14 @@
             "./node_modules"
         ],
         "types": [
-        ]
+        ],
+        "baseUrl": ".",
+        "paths": {
+            "*": [
+                "./node_modules/tns-core-modules/*",
+                "./node_modules/*"
+            ]
+        }
     },
     "exclude": [
         "demo",


### PR DESCRIPTION
This PR updates dependencies to latest/greatest for NativeScript. Also fixes small bug in the package.json for the plugin that referenced the wrong TypeScript definitions files (`index.d.ts` instead of `lan-scan.d.ts`).

Also bumps the package version up to 0.3.0 so NPM can be updated.